### PR TITLE
Bump PHP to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.2|^8.3",
+        "php": "^8.3",
         "magento/framework": "*",
         "hyva-themes/magento2-default-theme": "^1.3"
     },


### PR DESCRIPTION
The configuration does not supported PHP8.2
https://github.com/elgentos/magento2-store-switcher/blob/main/src/Model/Configuration.php#L21
https://3v4l.org/kdHDk