### PR TITLE
Fix: dropdown background transparent to white

### DIFF
--- a/src/view/frontend/templates/switcher.phtml
+++ b/src/view/frontend/templates/switcher.phtml
@@ -45,7 +45,7 @@ $availableStores     = $storeSwitcher->getStores($currentStore->getCode());
         x-cloak
         class="
             absolute right-0 z-20 w-40 py-2 mt-2 -mr-4 px-1 overflow-auto origin-top-right rounded-sm
-            shadow-lg sm:w-48 lg:mt-3 bg-container-lighter
+            shadow-lg sm:w-48 lg:mt-3 bg-container-lighter bg-white
         "
     >
         <ul>

--- a/src/view/frontend/templates/switcher.phtml
+++ b/src/view/frontend/templates/switcher.phtml
@@ -45,7 +45,7 @@ $availableStores     = $storeSwitcher->getStores($currentStore->getCode());
         x-cloak
         class="
             absolute right-0 z-20 w-40 py-2 mt-2 -mr-4 px-1 overflow-auto origin-top-right rounded-sm
-            shadow-lg sm:w-48 lg:mt-3 bg-container-lighter bg-white
+            shadow-lg sm:w-48 lg:mt-3 bg-white
         "
     >
         <ul>


### PR DESCRIPTION
The selector dropdown has a transparent background, adding the bg-white class fixes this.